### PR TITLE
ci: limit the GITHUB_TOKEN permissions of the workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/shared.build.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   build-and-release:
     name: Build and deploy to WordPress.org

--- a/.github/workflows/shared.build.yml
+++ b/.github/workflows/shared.build.yml
@@ -3,6 +3,9 @@ name: build
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Build project


### PR DESCRIPTION
Without an explicit permissions block the token gets the repository default, which is write access to almost everything - flagged by CodeQL as "Workflow does not contain permissions". Each workflow now declares the least it needs: contents: read to check the repository out, and contents: write only where a release asset is uploaded with GITHUB_TOKEN.